### PR TITLE
Refactor small syntax api

### DIFF
--- a/server/expectation-checker.js
+++ b/server/expectation-checker.js
@@ -8,7 +8,7 @@ var syntax = require('./syntax');
 var expectationChecker = {
 
   HasBinding: function (ast, binding) {
-    return syntax.declarationsOf(ast).some(j.matchesAny([
+    return syntax.hasDeclaration(ast, j.matchesAny([
       { type: 'FunctionDeclaration', id: syntax.identifier(binding), _: j._ },
       { type: 'VariableDeclarator', id: syntax.identifier(binding), _: j._ }
     ]));

--- a/server/expectation-checker.js
+++ b/server/expectation-checker.js
@@ -15,8 +15,11 @@ var expectationChecker = {
   },
 
   HasUsage: function (ast, binding, target) {
-    return syntax.expressionsOf(ast, binding).some(function (node) {
-      return expressionHasUsage(node, target);
+    return syntax.hasExpression(ast, binding, function (expression) {
+      return j.match(expression, [
+        j.case(syntax.identifier(target), _.constant(true)),
+        j.case(j._                      , _.constant(false))
+      ]);
     });
   },
 
@@ -25,15 +28,6 @@ var expectationChecker = {
   }
 
 };
-
-function expressionHasUsage(arg, target) {
-  return syntax.explore(arg, function (expression) {
-    return j.match(expression, [
-      j.case(syntax.identifier(target), _.constant(true)),
-      j.case(j._                      , _.constant(false))
-    ]);
-  });
-}
 
 function isNot(value) {
   return /not/i.test(value);

--- a/server/syntax.js
+++ b/server/syntax.js
@@ -6,6 +6,12 @@ var esprima = require('esprima');
 
 var extensions = require('./extensions');
 
+function hasExpression(ast, binding, f) {
+  return expressionsOf(ast, binding).some(function (node) {
+    return explore(node, f);
+  });
+}
+
 function expressionsOf(ast, binding) {
   return declarationsOf(ast).concatMap(function (node) {
     return j.match(node, [
@@ -81,5 +87,6 @@ module.exports = {
   explore: explore,
   identifier: identifier,
   expressionsOf: expressionsOf,
-  declarationsOf: declarationsOf
+  declarationsOf: declarationsOf,
+  hasExpression: hasExpression
 };

--- a/server/syntax.js
+++ b/server/syntax.js
@@ -6,6 +6,23 @@ var esprima = require('esprima');
 
 var extensions = require('./extensions');
 
+//======
+//Public
+//======
+
+
+// common patterns
+
+function identifier(binding) {
+  return { type: 'Identifier', name: binding };
+}
+
+function type(t) {
+  return { type: t, _: j._ };
+}
+
+// predicates
+
 function hasExpression(ast, binding, f) {
   return expressionsOf(ast, binding).some(function (node) {
     return explore(node, f);
@@ -15,6 +32,13 @@ function hasExpression(ast, binding, f) {
 function hasDeclaration(ast, f) {
   return declarationsOf(ast).some(f);
 }
+
+//=======
+//Private
+//=======
+
+
+// low level iteration
 
 function expressionsOf(ast, binding) {
   return declarationsOf(ast).concatMap(function (node) {
@@ -29,6 +53,25 @@ function expressionsOf(ast, binding) {
     ]);
   });
 }
+
+
+function declarationsOf(ast) {
+  return ast.body.concatMap(function (node) {
+    return j.match(node, [
+      j.case(type('FunctionDeclaration'), function () {
+        return [node];
+      }),
+      j.case(type('VariableDeclaration'), function () {
+        return node.declarations;
+      }),
+      j.case(j._ , function () {
+        return [];
+      })
+    ]);
+  });
+}
+
+// Expressions exploration
 
 function explore(arg, f) {
   return f(arg) || subExpressionsOf(arg).some(function (subExpression) {
@@ -61,30 +104,6 @@ function subExpressionsOf(exp) {
     }),
     j.case(j._, _.constant([]))
   ]);
-}
-
-function identifier(binding) {
-  return { type: 'Identifier', name: binding };
-}
-
-function type(t) {
-  return { type: t, _: j._ };
-}
-
-function declarationsOf(ast) {
-  return ast.body.concatMap(function (node) {
-    return j.match(node, [
-      j.case(type('FunctionDeclaration'), function () {
-        return [node];
-      }),
-      j.case(type('VariableDeclaration'), function () {
-        return node.declarations;
-      }),
-      j.case(j._ , function () {
-        return [];
-      })
-    ]);
-  });
 }
 
 module.exports = {

--- a/server/syntax.js
+++ b/server/syntax.js
@@ -12,6 +12,10 @@ function hasExpression(ast, binding, f) {
   });
 }
 
+function hasDeclaration(ast, f) {
+  return declarationsOf(ast).some(f);
+}
+
 function expressionsOf(ast, binding) {
   return declarationsOf(ast).concatMap(function (node) {
     return j.match(node, [
@@ -84,9 +88,7 @@ function declarationsOf(ast) {
 }
 
 module.exports = {
-  explore: explore,
   identifier: identifier,
-  expressionsOf: expressionsOf,
-  declarationsOf: declarationsOf,
-  hasExpression: hasExpression
+  hasExpression: hasExpression,
+  hasDeclaration: hasDeclaration
 };


### PR DESCRIPTION
Since we don't have Haskell's lazy evaluation here, it is a better idea to expose only syntax functions that expose high level callback base iteration - `hasExpression`, `hasDeclaration`, instead of plain functions `expressionsOf` and `declarationsOf`.

That way checker module doesn't have to directly use `explore` to iterate to expressions list.
