### PR TITLE
Test fails on evals/requires

### DIFF
--- a/src/server/test-compiler.es6
+++ b/src/server/test-compiler.es6
@@ -23,6 +23,10 @@ function writeContent(path, content) {
 function compile(body) {
   return `
     var assert = require("assert");
+    require = function() { throw new Error("require not available") };
+    module.require = require;
+    eval = function() { throw new Error("eval not available") };
+
     ${body.extra}
     ${body.content}
     ${body.test}`;

--- a/src/test/fixture/index.es6
+++ b/src/test/fixture/index.es6
@@ -6,7 +6,7 @@ module.exports = {
       body: {
         test: `
           describe("Test True", function() {
-            it("should returns true", function() {
+            it("should return true", function() {
               assert(testTrue());
             });
           });`,
@@ -26,7 +26,7 @@ module.exports = {
       body: {
         test: `
           describe("Test True", function() {
-            it("should returns true", function() {
+            it("should return true", function() {
               assert(testTrue());
             });
           });`,
@@ -47,7 +47,7 @@ module.exports = {
         test: `
           var fs = require('fs');
           describe("Test True", function() {
-            it("should returns true", function() {
+            it("should return true", function() {
               assert(testTrue());
             });
           });`,

--- a/src/test/fixture/index.es6
+++ b/src/test/fixture/index.es6
@@ -42,7 +42,7 @@ module.exports = {
         out: /0 passing \(\d+ms\)\s+1 failing/
       }
     },
-    failOnMaliciousCode: {
+    failOnMaliciousCodeUsingRequire: {
       body: {
         test: `
           var fs = require('fs');
@@ -61,6 +61,27 @@ module.exports = {
       expected: {
         exit: 'failed',
         out: /Error: require not available/
+      }
+    }    ,
+    failOnMaliciousCodeUsingEval: {
+      body: {
+        test: `
+          eval("alert('I\'m evil!')");
+          describe("Test True", function() {
+            it("should return true", function() {
+              assert(testTrue());
+            });
+          });`,
+        extra: '',
+        content: `
+          function testTrue() {
+            return true;
+          }`,
+        expectations: []
+      },
+      expected: {
+        exit: 'failed',
+        out: /Error: eval not available/
       }
     }
   },

--- a/src/test/fixture/index.es6
+++ b/src/test/fixture/index.es6
@@ -41,6 +41,27 @@ module.exports = {
         exit: 'failed',
         out: /0 passing \(\d+ms\)\s+1 failing/
       }
+    },
+    failOnMaliciousCode: {
+      body: {
+        test: `
+          var fs = require('fs');
+          describe("Test True", function() {
+            it("should returns true", function() {
+              assert(testTrue());
+            });
+          });`,
+        extra: '',
+        content: `
+          function testTrue() {
+            return true;
+          }`,
+        expectations: []
+      },
+      expected: {
+        exit: 'failed',
+        out: /Error: require not available/
+      }
     }
   },
   withExpectation : {

--- a/src/test/server.test.es6
+++ b/src/test/server.test.es6
@@ -24,7 +24,8 @@ describe('POST /test', () => {
 
   it('should return 200 when excercise passed', assert.bind(it, 'ok'));
   it('should return 200 when excercise failed', assert.bind(it, 'fail'));
-  it('should return 200 when excercise failed on malicious code', assert.bind(it, 'failOnMaliciousCode'));
+  it('should return 200 when excercise failed on malicious code that uses require', assert.bind(it, 'failOnMaliciousCodeUsingRequire'));
+  it('should return 200 when excercise failed on malicious code that uses eval', assert.bind(it, 'failOnMaliciousCodeUsingEval'));
 
   let assertExpectation = (testType, done) => {
     let excecise = fixture.withExpectation[testType];

--- a/src/test/server.test.es6
+++ b/src/test/server.test.es6
@@ -24,6 +24,7 @@ describe('POST /test', () => {
 
   it('should returns 200 when excercise passed', assert.bind(it, 'ok'));
   it('should returns 200 when excercise failed', assert.bind(it, 'fail'));
+  it('should returns 200 when excercise failed on malicious code', assert.bind(it, 'failOnMaliciousCode'));
 
   let assertExpectation = (testType, done) => {
     let excecise = fixture.withExpectation[testType];

--- a/src/test/server.test.es6
+++ b/src/test/server.test.es6
@@ -22,9 +22,9 @@ describe('POST /test', () => {
       });
   };
 
-  it('should returns 200 when excercise passed', assert.bind(it, 'ok'));
-  it('should returns 200 when excercise failed', assert.bind(it, 'fail'));
-  it('should returns 200 when excercise failed on malicious code', assert.bind(it, 'failOnMaliciousCode'));
+  it('should return 200 when excercise passed', assert.bind(it, 'ok'));
+  it('should return 200 when excercise failed', assert.bind(it, 'fail'));
+  it('should return 200 when excercise failed on malicious code', assert.bind(it, 'failOnMaliciousCode'));
 
   let assertExpectation = (testType, done) => {
     let excecise = fixture.withExpectation[testType];
@@ -44,7 +44,7 @@ describe('POST /test', () => {
       });
   };
 
-  it('should returns 200 when excercise with expectations passed', assertExpectation.bind(it, 'ok'));
-  it('should returns 200 when excercise with expectations failed', assertExpectation.bind(it, 'fail'));
+  it('should return 200 when excercise with expectations passed', assertExpectation.bind(it, 'ok'));
+  it('should return 200 when excercise with expectations failed', assertExpectation.bind(it, 'fail'));
 
 });


### PR DESCRIPTION
Although we should simply abort evaluation of submissions with potential malicious  code instead of making test fail, the proposed approach in this PR is better than nothing. 
